### PR TITLE
Add support for specifying wanted version

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,6 +49,7 @@ when 'binary'
     Chef::Log.error("this distro is not supported")
   end
   package 'sysdig' do
+    version node['sysdig']['version']
     action :install
   end
 else


### PR DESCRIPTION
Current version of the cookbook doesn't allow to specify version. This is nice to have if at some point sysdig breaks backwards compatibility of if you just wanna keep your packages up to date and on same version throughout your hosts.

This PR just adds this one option to add this support. If `node['sysdig']['version']`nil (out of box for this cookbook) it will still install whatever is at the repos at that moment.

